### PR TITLE
[update] JSON write too conform to NDJSON standard

### DIFF
--- a/factli/get_posts.py
+++ b/factli/get_posts.py
@@ -109,8 +109,9 @@ def ct_get_posts(list_id, count, access_token, start_date, end_date, log_level, 
                         pathlib.Path(f'{x}').mkdir(exist_ok=True)
                         os.chdir(f'{str0}/results/{list_id}/{x}')
 
-                        with open(f'{start_date}_{end_date}.json', 'a', encoding='utf8') as f:
-                            json.dump(json_response['result']['posts'][i-1], f, ensure_ascii=False, indent=4)
+                        with open(f'{start_date}_{end_date}.ndjson', 'a', encoding='utf8') as f:
+                            json.dump(json_response['result']['posts'][i-1], f, ensure_ascii=False)
+                            f.write("\n")
                         next_page_query = json_response['result']['pagination']['nextPage']
 
                         os.chdir(f'{str0}/results/{list_id}')


### PR DESCRIPTION
# Problem

JSON writer implementation wrote (concatted) multiple json objects into one file which lead to unreadable JSON structure.

# Fix

1. minify json so that each JSON objects is only one line in the file
2. add `\n` after each object
3. name files `xxx.ndjson`